### PR TITLE
docs: SFSymbolsのリンクを追加

### DIFF
--- a/json/howToMake.md
+++ b/json/howToMake.md
@@ -58,7 +58,7 @@
 | ----------------- | ------------------------------------------------------------ |
 | text              | `"text"`に指定した文字をラベルとして表示します。                       |
 | main_and_sub      | `"main"`に指定した1文字を1行目に大きめに、`"sub"`に指定した文字列を2行目に小さめに表示します。 |
-| system_image      | `"system_image"`に指定した画像をラベルとして表示します。指定できる値は以下の通りです。<br />この画像はSFSymbolsから取得されます。 |
+| system_image      | `"system_image"`に指定した画像をラベルとして表示します。指定できる値の一例は以下の通りです。<br />この画像は[SFSymbols](https://developer.apple.com/sf-symbols/)から取得されます。 |
 
 <img src="../resource/symbols.png" style="zoom:15%;" />
 

--- a/python/howToMake.md
+++ b/python/howToMake.md
@@ -47,7 +47,7 @@ design = KeyDesign(
 | ---------------- | --------------- | ------------------------------------------------------------ |
 | TextLabel        | text: str       | 指定した文字をラベルとして表示します。                       |
 | MainAndSubLabel | main: str, sub: str | `main`に指定した1文字を1行目に大きめに、`sub`に指定した文字を2行目に小さめに表示します。 |
-| SystemImageLabel | identifier: str | 指定した名前の画像をラベルとして表示します。指定できる値は以下の通りです。<br />この画像はSFSymbolsから取得されます。 |
+| SystemImageLabel | identifier: str | 指定した名前の画像をラベルとして表示します。指定できる値の一例は以下の通りです。<br />この画像は[SFSymbols](https://developer.apple.com/sf-symbols/)から取得されます。 |
 
 <img src="../resource/symbols.png" style="zoom:15%;" />
 

--- a/swift/howToMake.md
+++ b/swift/howToMake.md
@@ -49,7 +49,7 @@ design: .init(label: .text("@#/&_"), color: .normal)
 | -------------------- | ------------------------------------------------------------ |
 | .text(String)        | 指定した文字をラベルとして表示します。                       |
 | .mainAndSub(String, String) | 1つ目に指定した1文字を1行目に大きめに、2つ目に指定した文字を2行目に小さめに表示します。 |
-| .systemImage(String) | 指定した名前の画像をラベルとして表示します。指定できる値は以下の通りです。<br />この画像はSFSymbolsから取得されます。 |
+| .systemImage(String) | 指定した名前の画像をラベルとして表示します。指定できる値の一例は以下の通りです。<br />この画像は[SFSymbols](https://developer.apple.com/sf-symbols/)から取得されます。 |
 
 <img src="../resource/symbols.png" style="zoom:15%;" />
 


### PR DESCRIPTION
#39 
表現が意図に沿っているか確認お願いします。

```md
指定した名前の画像をラベルとして表示します。指定できる値の一例は以下の通りです。<br />この画像は[SFSymbols](https://developer.apple.com/sf-symbols/)から取得されます。
```